### PR TITLE
fixed a bug where it behaved unexpectedly when the mask contained number

### DIFF
--- a/Pod/Classes/VMaskTextField.m
+++ b/Pod/Classes/VMaskTextField.m
@@ -50,7 +50,7 @@ NSString * kVMaskTextFieldDefaultChar = @"#";
             if (currentCharMask == '#') {
                 break;
             }
-            if (isnumber(currentChar)) {
+            if (isnumber(currentChar) && currentChar != currentCharMask) {
                 needAppend = YES;
             }
             [returnText appendString:[NSString stringWithFormat:@"%c",currentCharMask]];


### PR DESCRIPTION
When textField.mask is set to a string that includes numbers (e.g "0(###) ### ## ##"), textField takes multiple inputs when a single character is entered.
