### PR TITLE
Add possibility to disallow editing between characters.

### DIFF
--- a/Example/Pods/VMaskTextField/Pod/Classes/VMaskTextField.h
+++ b/Example/Pods/VMaskTextField/Pod/Classes/VMaskTextField.h
@@ -5,6 +5,7 @@
 @property (nonatomic,strong) NSString * mask;
 @property (nonatomic,strong) NSString * raw;
 @property (nonatomic,strong) NSString * defaultCharMask;
+@property (nonatomic,assign) BOOL disallowEditingBetweenCharacters;
 
 -(double) rawToDouble;
 -(float) rawToFloat;

--- a/Example/Pods/VMaskTextField/Pod/Classes/VMaskTextField.m
+++ b/Example/Pods/VMaskTextField/Pod/Classes/VMaskTextField.m
@@ -33,6 +33,16 @@ NSString * kVMaskTextFieldDefaultChar = @"#";
 }
 
 - (BOOL)shouldChangeCharactersInRange:(NSRange)range replacementString:(NSString *)string{
+    if (self.disallowEditingBetweenCharacters) {
+        NSInteger minimanAllowedLocation = self.text.length - 1;
+        NSInteger editionLocation = range.location;
+        if (editionLocation < minimanAllowedLocation) {
+            [self resignFirstResponder]; // Do a trick with first responded to move
+            [self becomeFirstResponder]; // cursor to the end of text field
+            return NO;
+        }
+    }
+  
     NSString * currentTextDigited = [self.text stringByReplacingCharactersInRange:range withString:string];
     if (string.length == 0) {
         unichar lastCharDeleted = 0;

--- a/Pod/Classes/VMaskTextField.h
+++ b/Pod/Classes/VMaskTextField.h
@@ -5,6 +5,7 @@
 @property (nonatomic,strong) NSString * mask;
 @property (nonatomic,strong) NSString * raw;
 @property (nonatomic,strong) NSString * defaultCharMask;
+@property (nonatomic,assign) BOOL disallowEditingBetweenCharacters;
 
 -(double) rawToDouble;
 -(float) rawToFloat;

--- a/Pod/Classes/VMaskTextField.m
+++ b/Pod/Classes/VMaskTextField.m
@@ -23,6 +23,16 @@ NSString * kVMaskTextFieldDefaultChar = @"#";
 }
 
 - (BOOL)shouldChangeCharactersInRange:(NSRange)range replacementString:(NSString *)string{
+    if (self.disallowEditingBetweenCharacters) {
+        NSInteger minimanAllowedLocation = self.text.length - 1;
+        NSInteger editionLocation = range.location;
+        if (editionLocation < minimanAllowedLocation) {
+            [self resignFirstResponder]; // Do a trick with first responded to move
+            [self becomeFirstResponder]; // cursor to the end of text field
+            return NO;
+        }
+    }
+    
     NSString * currentTextDigited = [self.text stringByReplacingCharactersInRange:range withString:string];
     if (string.length == 0) {
         unichar lastCharDeleted = 0;


### PR DESCRIPTION
There is a situation, when user enters something to the masked text field, then he moves cursor to middle of text and edit it. I don't know if this is not a bug, but I guess developer should have at least a possibility to disallow edition between characters.