### PR TITLE
Implementation of `raw` property

### DIFF
--- a/Pod/Classes/VMaskTextField.m
+++ b/Pod/Classes/VMaskTextField.m
@@ -46,6 +46,18 @@ NSString * kVMaskTextFieldDefaultChar = @"#";
     return [VMaskEditor shouldChangeCharactersInRange:range replacementString:string textField:self mask:_mask];
 }
 
+-(NSString *)raw{
+    NSMutableString *string = [NSMutableString new];
+    for (int i=0; i<self.text.length; i++) {
+        unichar charMask = [self.mask characterAtIndex:i];
+        unichar charText = [self.text characterAtIndex:i];
+        if (charMask == '#') {
+            [string appendFormat:@"%c", charText];
+        }
+    }
+    return string;
+}
+
 -(double) rawToDouble{
     return [_raw doubleValue];
 }

--- a/Pod/Classes/VMaskTextField.m
+++ b/Pod/Classes/VMaskTextField.m
@@ -25,7 +25,6 @@ NSString * kVMaskTextFieldDefaultChar = @"#";
 
 -(void) setTextWithMask:(NSString *) text{
     NSAssert(_mask!=nil, @"Mask is nil.");
-    self.text = @"";
     for (int i = 0; i < text.length; i++) {
         if (self.text.length == _mask.length) {
             break;

--- a/Pod/Classes/VMaskTextField.m
+++ b/Pod/Classes/VMaskTextField.m
@@ -25,6 +25,7 @@ NSString * kVMaskTextFieldDefaultChar = @"#";
 
 -(void) setTextWithMask:(NSString *) text{
     NSAssert(_mask!=nil, @"Mask is nil.");
+    self.text = @"";
     for (int i = 0; i < text.length; i++) {
         if (self.text.length == _mask.length) {
             break;


### PR DESCRIPTION
This pull request implements the return of `raw` property. Some users related that this property always returns nil (#11), it happens for me too.

Another thing is to clear the text before `setTextWithMask:`. If you set a string in interface builder, for example, when you call `setTextWithMask` the new text appends the old text (setted in interface builder).
For example:
- Your mask is `"##-##-##"`;
- You set the `VMaksTextField` text with `12` in interface builder;
- You call `[self.textField setTextWithMask:@"098765"];`
- The final result is `12-09-87`.

Semantically, `setText` will replace all text.
