### PR TITLE
Make VMaskEditor send an EditingChanged event when setting the value …

### DIFF
--- a/Pod/Classes/VMaskEditor.m
+++ b/Pod/Classes/VMaskEditor.m
@@ -23,6 +23,7 @@
             currentTextDigited = [currentTextDigited substringToIndex:[currentTextDigited length] - 1];
         }
         textField.text = currentTextDigited;
+        [textField sendActionsForControlEvents:UIControlEventEditingChanged];
         return NO;
     }
     
@@ -63,6 +64,7 @@
         [returnText appendString:string];
     }
     textField.text = returnText;
+    [textField sendActionsForControlEvents:UIControlEventEditingChanged];
     return NO;
 }
 


### PR DESCRIPTION
…of textField.

This correction solves an issue where a VMaskTextField would not respond to EditingChanged events.